### PR TITLE
fix: do not throw if `process` is undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tybys/wasm-util",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "WASI polyfill for browser and some wasm util",
   "main": "./lib/cjs/index.js",
   "module": "./dist/wasm-util.esm-bundler.js",

--- a/src/wasi/preview1.ts
+++ b/src/wasi/preview1.ts
@@ -117,13 +117,7 @@ function defineName<T extends Function> (name: string, f: T): T {
 }
 
 function syscallWrap<T extends (this: WASI, ...args: any[]) => WasiErrno | PromiseLike<WasiErrno>> (self: WASI, name: string, f: T): T {
-  return defineName(name, function () {
-    if (process.env.NODE_DEBUG_NATIVE === 'wasi') {
-      const args = Array.prototype.slice.call(arguments)
-      let debugArgs = [`${name}(${Array.from({ length: arguments.length }).map(() => '%d').join(', ')})`]
-      debugArgs = debugArgs.concat(args)
-      console.debug.apply(console, debugArgs)
-    }
+  function tryCall (): WasiErrno | PromiseLike<WasiErrno> {
     let r: WasiErrno | PromiseLike<WasiErrno>
     try {
       r = f.apply(self, arguments as any)
@@ -135,7 +129,32 @@ function syscallWrap<T extends (this: WASI, ...args: any[]) => WasiErrno | Promi
       return r.then(_ => _, handleError)
     }
     return r
-  }) as unknown as T
+  }
+
+  let debug = false
+
+  const NODE_DEBUG_NATIVE = (() => {
+    try {
+      return process.env.NODE_DEBUG_NATIVE
+    } catch (_) {
+      return undefined
+    }
+  })()
+  if (typeof NODE_DEBUG_NATIVE === 'string' && NODE_DEBUG_NATIVE.split(',').includes('wasi')) {
+    debug = true
+  }
+
+  return debug
+    ? defineName(name, function () {
+      const args = Array.prototype.slice.call(arguments)
+      let debugArgs = [`${name}(${Array.from({ length: arguments.length }).map(() => '%d').join(', ')})`]
+      debugArgs = debugArgs.concat(args)
+      console.debug.apply(console, debugArgs)
+      return tryCall()
+    }) as unknown as T
+    : defineName(name, function () {
+      return tryCall()
+    }) as unknown as T
 }
 
 function resolvePathSync (fs: IFs, fileDescriptor: FileDescriptor, path: string, flags: number): string {

--- a/src/wasi/preview1.ts
+++ b/src/wasi/preview1.ts
@@ -116,21 +116,21 @@ function defineName<T extends Function> (name: string, f: T): T {
   return f
 }
 
-function syscallWrap<T extends (this: WASI, ...args: any[]) => WasiErrno | PromiseLike<WasiErrno>> (self: WASI, name: string, f: T): T {
-  function tryCall (): WasiErrno | PromiseLike<WasiErrno> {
-    let r: WasiErrno | PromiseLike<WasiErrno>
-    try {
-      r = f.apply(self, arguments as any)
-    } catch (err: any) {
-      return handleError(err)
-    }
-
-    if (isPromiseLike(r)) {
-      return r.then(_ => _, handleError)
-    }
-    return r
+function tryCall<T extends (this: WASI, ...args: any[]) => WasiErrno | PromiseLike<WasiErrno>> (f: T, wasi: WASI, args: any[]): WasiErrno | PromiseLike<WasiErrno> {
+  let r: WasiErrno | PromiseLike<WasiErrno>
+  try {
+    r = f.apply(wasi, args)
+  } catch (err: any) {
+    return handleError(err)
   }
 
+  if (isPromiseLike(r)) {
+    return r.then(_ => _, handleError)
+  }
+  return r
+}
+
+function syscallWrap<T extends (this: WASI, ...args: any[]) => WasiErrno | PromiseLike<WasiErrno>> (self: WASI, name: string, f: T): T {
   let debug = false
 
   const NODE_DEBUG_NATIVE = (() => {
@@ -150,10 +150,10 @@ function syscallWrap<T extends (this: WASI, ...args: any[]) => WasiErrno | Promi
       let debugArgs = [`${name}(${Array.from({ length: arguments.length }).map(() => '%d').join(', ')})`]
       debugArgs = debugArgs.concat(args)
       console.debug.apply(console, debugArgs)
-      return tryCall()
+      return tryCall(f, self, args)
     }) as unknown as T
     : defineName(name, function () {
-      return tryCall()
+      return tryCall(f, self, arguments as any)
     }) as unknown as T
 }
 


### PR DESCRIPTION
#4 