### PR TITLE
fix(wasi): make path_open work on Windows (POSIX-only resolve + Linux-vs-Windows flag bits)

### DIFF
--- a/src/wasi/path.ts
+++ b/src/wasi/path.ts
@@ -3,6 +3,139 @@ import { validateString } from './util'
 const CHAR_DOT = 46 /* . */
 const CHAR_FORWARD_SLASH = 47 /* / */
 
+const CHAR_BACKWARD_SLASH = 92 /* \ */
+const CHAR_COLON = 58 /* : */
+const CHAR_UPPERCASE_A = 65 /* A */
+const CHAR_UPPERCASE_Z = 90 /* Z */
+const CHAR_LOWERCASE_A = 97 /* a */
+const CHAR_LOWERCASE_Z = 122 /* z */
+
+function isPathSeparatorWin (code: number): boolean {
+  return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH
+}
+
+function isWindowsDeviceRoot (code: number): boolean {
+  return (code >= CHAR_UPPERCASE_A && code <= CHAR_UPPERCASE_Z) ||
+         (code >= CHAR_LOWERCASE_A && code <= CHAR_LOWERCASE_Z)
+}
+
+const _isWin32: boolean =
+  typeof process !== 'undefined' && (process as any).platform === 'win32'
+
+/**
+ * Windows variant of `resolve()`. Mirrors Node's `path.win32.resolve`
+ * semantics enough for the WASI shim's needs (drive-letter absolutes
+ * + UNC paths + per-drive cwd lookups via `process.env`/`process.cwd`).
+ *
+ * Why this is needed: on Windows, `FileDescriptor.realPath` is the
+ * host realpath returned by `fs.realpathSync(realPath, 'utf8')` — the
+ * backslash form `D:\…`. The POSIX-only `resolveImpl` below only
+ * treats `/` as a separator, reads `D` as non-`/`, decides realPath
+ * is "relative", and produces a garbage joined path. Downstream
+ * `fs.openSync(garbage)` then returns `EINVAL` and the WASI caller
+ * sees a permanent failure. This function gives us the correct
+ * Windows-style resolution without taking a Node-only `path` import
+ * (which would break browser bundles of this package).
+ *
+ * Cribbed from Node's `lib/path.js` `win32.resolve()` (MIT-licensed),
+ * trimmed to what WASI realpath resolution actually exercises.
+ */
+function resolveWin32 (args: string[]): string {
+  let resolvedDevice = ''
+  let resolvedTail = ''
+  let resolvedAbsolute = false
+
+  for (let i = args.length - 1; i >= -1; i--) {
+    let path: string
+    if (i >= 0) {
+      path = args[i]
+      validateString(path, 'path')
+      if (path.length === 0) continue
+    } else if (resolvedDevice.length === 0) {
+      path = (typeof process !== 'undefined' && typeof (process as any).cwd === 'function')
+        ? (process as any).cwd() as string
+        : ''
+    } else {
+      // Look up per-drive cwd via the `=X:` env var convention; fall back
+      // to the global cwd if absent.
+      const envKey = `=${resolvedDevice}`
+      const env = (typeof process !== 'undefined') ? (process as any).env : undefined
+      path = (env && typeof env[envKey] === 'string')
+        ? env[envKey] as string
+        : (typeof process !== 'undefined' && typeof (process as any).cwd === 'function')
+          ? (process as any).cwd() as string
+          : ''
+      if (path === undefined ||
+          (path.slice(0, 2).toLowerCase() !== resolvedDevice.toLowerCase() &&
+           path.charCodeAt(2) === CHAR_BACKWARD_SLASH)) {
+        path = `${resolvedDevice}\\`
+      }
+    }
+
+    const len = path.length
+    let rootEnd = 0
+    let device = ''
+    let isAbsolute = false
+    const code = path.charCodeAt(0)
+
+    if (len === 1) {
+      if (isPathSeparatorWin(code)) {
+        rootEnd = 1
+        isAbsolute = true
+      }
+    } else if (isPathSeparatorWin(code)) {
+      isAbsolute = true
+      if (isPathSeparatorWin(path.charCodeAt(1))) {
+        // UNC path: `\\server\share\…`
+        let j = 2
+        let last = j
+        while (j < len && !isPathSeparatorWin(path.charCodeAt(j))) j++
+        if (j < len && j !== last) {
+          const firstPart = path.slice(last, j)
+          last = j
+          while (j < len && isPathSeparatorWin(path.charCodeAt(j))) j++
+          if (j < len && j !== last) {
+            last = j
+            while (j < len && !isPathSeparatorWin(path.charCodeAt(j))) j++
+            if (j === len || j !== last) {
+              device = `\\\\${firstPart}\\${path.slice(last, j)}`
+              rootEnd = j
+            }
+          }
+        }
+      } else {
+        rootEnd = 1
+      }
+    } else if (isWindowsDeviceRoot(code) && path.charCodeAt(1) === CHAR_COLON) {
+      device = path.slice(0, 2)
+      rootEnd = 2
+      if (len > 2 && isPathSeparatorWin(path.charCodeAt(2))) {
+        isAbsolute = true
+        rootEnd = 3
+      }
+    }
+
+    if (device.length > 0) {
+      if (resolvedDevice.length > 0) {
+        if (device.toLowerCase() !== resolvedDevice.toLowerCase()) continue
+      } else {
+        resolvedDevice = device
+      }
+    }
+
+    if (resolvedAbsolute) {
+      if (resolvedDevice.length > 0) break
+    } else {
+      resolvedTail = `${path.slice(rootEnd)}\\${resolvedTail}`
+      resolvedAbsolute = isAbsolute
+      if (isAbsolute && resolvedDevice.length > 0) break
+    }
+  }
+
+  resolvedTail = normalizeString(resolvedTail, !resolvedAbsolute, '\\', isPathSeparatorWin)
+  return resolvedDevice + (resolvedAbsolute ? '\\' : '') + resolvedTail || '.'
+}
+
 function isPosixPathSeparator (code: number): boolean {
   return code === CHAR_FORWARD_SLASH
 }
@@ -74,6 +207,13 @@ function normalizeString (path: string, allowAboveRoot: boolean, separator: stri
 }
 
 export function resolve (...args: string[]): string {
+  // On Windows, host paths are `D:\…` style. The POSIX-only resolver
+  // below treats `D` as a non-`/` character and produces garbage; route
+  // to the Windows-aware variant. POSIX hosts (Linux/macOS/browser)
+  // run the original code path unchanged — `_isWin32` is constant-folded
+  // away on those targets.
+  if (_isWin32) return resolveWin32(args)
+
   let resolvedPath = ''
   let resolvedAbsolute = false
 

--- a/src/wasi/preview1.ts
+++ b/src/wasi/preview1.ts
@@ -2,6 +2,24 @@ import { _WebAssembly } from '../webassembly'
 import type { IFs, IFsPromises, FileHandle } from './fs'
 import { resolve } from './path'
 
+// Linux fcntl flag bits ↔ Windows libuv flag bits. `pathOpen()` builds
+// `flagsRes` using Linux constants (O_CREAT=0x40, O_EXCL=0x80,
+// O_APPEND=0x400). Windows libuv expects different bits (O_CREAT=0x100,
+// O_EXCL=0x400, O_APPEND=0x8). Without translation,
+// `fs.openSync(path, 0x241 /* L:WRONLY|CREAT|TRUNC */)` is rejected
+// with EINVAL because Linux's 0x40 happens to mean O_TEMPORARY on
+// Windows — and O_TEMPORARY without O_CREAT is invalid.
+const _isWin32Flags: boolean =
+  typeof process !== 'undefined' && (process as any).platform === 'win32'
+function _toWinOpenFlags (f: number): number {
+  let r = f & 3                  // RDONLY/WRONLY/RDWR — same on both
+  if ((f & 0x40) !== 0) r |= 0x100   // O_CREAT:  Linux 0x40  -> Windows 0x100
+  if ((f & 0x80) !== 0) r |= 0x400   // O_EXCL:   Linux 0x80  -> Windows 0x400
+  if ((f & 0x200) !== 0) r |= 0x200  // O_TRUNC:  same value on both
+  if ((f & 0x400) !== 0) r |= 0x8    // O_APPEND: Linux 0x400 -> Windows 0x8
+  return r
+}
+
 import {
   WasiErrno,
   WasiRights,
@@ -1235,7 +1253,7 @@ export class WASI {
         const pathString = decoder.decode(unsharedSlice(HEAPU8, path, path + path_len))
         const fs = getFs(this) as IFs
         const resolved_path = resolvePathSync(fs, fileDescriptor, pathString, dirflags)
-        const r = fs.openSync(resolved_path, flagsRes, 0o666)
+        const r = fs.openSync(resolved_path, _isWin32Flags ? _toWinOpenFlags(flagsRes) : flagsRes, 0o666)
         const filetype = (wasi.fds as SyncTable).getFileTypeByFd(r)
         if (
           (filetype !== WasiFileType.DIRECTORY) &&
@@ -1293,7 +1311,7 @@ export class WASI {
         const pathString = decoder.decode(unsharedSlice(HEAPU8, path, path + path_len))
         const fs = getFs(this) as { promises: IFsPromises }
         const resolved_path = await resolvePathAsync(fs, fileDescriptor, pathString, dirflags)
-        const r = await fs.promises.open(resolved_path, flagsRes, 0o666)
+        const r = await fs.promises.open(resolved_path, _isWin32Flags ? _toWinOpenFlags(flagsRes) : flagsRes, 0o666)
         const filetype = await (wasi.fds as AsyncTable).getFileTypeByFd(r)
         if ((o_flags & WasiFileControlFlag.O_DIRECTORY) !== 0 && filetype !== WasiFileType.DIRECTORY) {
           return WasiErrno.ENOTDIR


### PR DESCRIPTION
Hi!. Thanks for your great work!!

WASI's `path_open` is broken on Windows in two distinct ways. Both manifest as `fs.openSync(...)` returning `EINVAL` for valid Windows paths and standard write/create/truncate flag combos. After both fixes, a downstream consumer's full test suite passes on `windows-latest`.

## Issue 1 — POSIX-only `resolve()` mishandles `D:\…` host paths

`resolvePathSync()` / `resolvePathAsync()` in `src/wasi/preview1.ts` do `resolve(fileDescriptor.realPath, path)`, where `resolve` is the bundled POSIX-only `resolve` from `src/wasi/path.ts`. That `resolve` only treats `/` as a separator (`isPosixPathSeparator` checks `code === CHAR_FORWARD_SLASH`) and decides absoluteness by `path.charCodeAt(0) === CHAR_FORWARD_SLASH`.

But on Windows, `fileDescriptor.realPath` is set to the host realpath returned by `fs.realpathSync(realPath, 'utf8')` — i.e. backslash form `D:\a\b\c`. The POSIX resolver:

- reads `D` (0x44) as a non-`/` character
- decides realPath is "relative"
- joins with `/` (not `\`) and runs `normalizeString()` with POSIX-only separator detection
- returns a garbage string like `D:\a\b\c/sub/dir/reg.json`

Downstream `fs.openSync(garbage, ...)` then returns `EINVAL`.

## Issue 2 — Linux fcntl flag bits ≠ Windows libuv flag bits

`pathOpen()` computes `flagsRes` using **Linux** fcntl bit values:

| name | Linux | Windows libuv |
|---|---|---|
| `O_CREAT`  | `0x40`  | `0x100` |
| `O_EXCL`   | `0x80`  | `0x400` |
| `O_TRUNC`  | `0x200` | `0x200` (same) |
| `O_APPEND` | `0x400` | `0x008` |

…and passes that integer straight to `fs.openSync(path, flags)`. The standard Linux/WASI write-create-truncate combo `0x241 = O_WRONLY | O_CREAT | O_TRUNC` is interpreted by Windows as `O_WRONLY | O_TEMPORARY | O_TRUNC` — and `O_TEMPORARY` without `O_CREAT` is invalid → EINVAL.

## Fix

**Bug 1:** route `resolve()` through a Windows-aware variant (`resolveWin32`) on `process.platform === 'win32'`. The variant is **inlined** (no `import * from 'path'`) so the browser bundle stays clean — the POSIX-only resolver still runs everywhere except Node Windows. Implementation cribbed from Node's `lib/path.js` `win32.resolve()` (MIT-licensed), trimmed to what the WASI shim's realpath-resolution actually exercises (drives, UNC, per-drive cwd via the `=X:` env-var convention).

**Bug 2:** `_toWinOpenFlags()` translates the Linux flag bits to Windows libuv layout before calling `fs.openSync` / `fs.promises.open` in both the sync and async `path_open` implementations.

Both gated on a runtime `_isWin32` constant. POSIX hosts and browsers run the original code path unchanged.

## Patching paths only at the source `resolve()`

I considered patching every call site (`path_open`, `path_create_directory`, `path_remove_directory`, `path_filestat_get`, `path_link`, `path_rename`, `path_symlink`, `path_unlink_file`, `path_readlink`) — they all do `resolve(fileDescriptor.realPath, …)` inline. Routing the fix through `resolve()` itself means **all callers benefit from a single change**.

## How I found this

Working on a downstream consumer ([reg-viz/reg-cli](https://github.com/reg-viz/reg-cli) — a visual-regression CLI being ported from JS to Rust+Wasm) that uses `@tybys/wasm-util` for WASI-threads. On a Windows CI matrix, ~32/38 tests failed; the wasm CLI panicked on every reg.json/junit.xml/report.html/diff write with the `EINVAL` symptom. Diagnostic logging via patched local copies of `lib/{mjs,cjs}/wasi/{path,preview1}.{mjs,js}` surfaced both bugs.

Fix was first verified by `pnpm patch`-ing the published 0.9.0 artefact in [reg-viz/reg-cli#621](https://github.com/reg-viz/reg-cli/pull/621): Windows CI flipped from 32/38 fail → fully green. This PR is the proper upstream port.

## Tested

- `npx tsc --noEmit` clean
- Downstream `pnpm patch` of the published artefact (logically equivalent to this source change) makes Windows CI fully green.